### PR TITLE
[Improvement/Suggestion] add timewall.service as distributed file

### DIFF
--- a/data/timewall.service
+++ b/data/timewall.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Dynamic wallpapers daemon
+
+[Service]
+Type=simple
+ExecStart=timewall set --daemon
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This usually be installed by packager at one of these path:
- `/usr/lib/systemd/user/timewall.service` (Atleast for Arch Linux)
- `/lib/systemd/user/timewall.service`

in [PKGBUILD](https://aur.archlinux.org/packages/timewall):
```
install -Dm 644 "data/timewall.service" -t "${pkgdir}/usr/lib/systemd/user/"
```

So, all users on the machine can optionally enable it without creating the service file manually:
```
$ systemctl --user enable --now timewall.service
```

[systemd.unit.5](https://man.archlinux.org/man/systemd.unit.5)

Thanks for creating such an awesome tool! :)
