### PR TITLE
Background process support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "env_logger",
  "itertools",
  "lazy_static",
+ "libc",
  "libheif-rs",
  "log",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ threadpool = "1.8.1"
 toml = "0.8.19"
 wallpape-rs = "2.0.0"
 xml-rs = "0.8.24"
+libc = "0.2.137"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,9 @@ pub enum Action {
         /// Use light or dark variant
         #[arg(short, long, value_enum)]
         appearance: Option<Appearance>,
+        /// Delay between wallpaper changes in milliseconds
+        #[arg(long, default_value_t = 500)]
+        delay: u64,
     },
     /// Clear the wallpaper cache
     Clear {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,8 @@ fn main() -> Result<()> {
             file,
             daemon,
             appearance,
-        } => actions::set(file.as_ref(), daemon, appearance),
+            delay,
+        } => actions::set(file.as_ref(), daemon, appearance, delay),
         cli::Action::Clear { all } => {
             actions::clear(all);
             Ok(())


### PR DESCRIPTION
Extends the wallpaper setter to support long lived processes as described in https://github.com/bcyran/timewall/issues/140.

We 'make before break', creating a new process to set the background before killing the old. I've created a cleanup function that's used by the preview command to remove the last process setting the wallpaper. This could also be used by the daemon if signal handlers were implemented (though it seems a few dependencies would be required to do this). Notably the non-daemon set command does not clean up after itself.

I've tested this for a short lived command and it all seems to work okay. The only limitation is we aren't capturing it's stderr output anymore. I think we could create a thread to wait on the process to finish and print it's error status if that's an issue.

Do let me know if I'm holding Rust wrong anywhere, or if there's stylistic things to fix.