### PR TITLE
feat: Implement geoclue location cache fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1535,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1752,6 +1770,7 @@ dependencies = [
  "rstest",
  "seahash",
  "serde",
+ "serde_json",
  "signal-hook",
  "sun",
  "threadpool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ plist = "1.7.0"
 png = "0.17.14"
 seahash = "4.1.0"
 serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.138"
 signal-hook = "0.3.17"
 sun = "0.3.1"
 threadpool = "1.8.1"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Using sun position based wallpapers requires your approximate geographical locat
 By default, the GeoClue 2 service is used to automatically determine your location, unless you configure it manually (see the next section).
 You can disable GeoClue by setting `geoclue.enable` to `false`.
 
+If GeoClue is enabled but cannot retrieve the location, such as when in offline mode, `timewall` will automatically use the last known location by default.
+To disable this fallback behavior, set `geoclue.cache_fallback` to `false`.
+
 The `geoclue.prefer` setting specifies whether GeoClue should be prioritized over manual location when both are available.
 This can be useful if you prefer using automatic detection but want to fall back to manual configuration rather than encountering an error if GeoClue is unavailable (e.g. due to no internet connection).
 
@@ -168,6 +171,7 @@ If this time period elapses, `timewall` will either fall back to manual location
 ```toml
 [geoclue]
 enable = true
+cache_fallback = true
 prefer = false
 timeout = 1000
 ```

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -41,6 +41,14 @@ in {
             default = true;
             description = "Enable GeoClue 2 for automatic location detection.";
           };
+          cache_fallback = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether to fallback to the last known location if GeoClue 2 fails to return
+              a location.
+            '';
+          };
           prefer = lib.mkOption {
             type = lib.types.bool;
             default = false;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -22,15 +22,7 @@ impl Cache {
     /// E.g. `Cache::find("wallpapers")` will create 'wallpapers' directory in timewall
     /// directory in user's main cache directory.
     pub fn find(name: &str) -> Self {
-        let cache_dir = if let Result::Ok(path_str) = env::var("TIMEWALL_CACHE_DIR") {
-            PathBuf::from(path_str)
-        } else {
-            match ProjectDirs::from(APP_QUALIFIER, "", APP_NAME) {
-                Some(app_dirs) => app_dirs.cache_dir().to_path_buf(),
-                None => panic!("couldn't determine user's home directory"),
-            }
-        };
-        Self::in_dir(cache_dir.join(name))
+        Self::in_dir(get_cache_dir().join(name))
     }
 
     /// Load cache from a given directory. Create it if it doesn't exist.
@@ -94,15 +86,7 @@ pub struct LastWallpaper {
 impl LastWallpaper {
     /// Find user's cache directory and load instance from there.
     pub fn find() -> Self {
-        let cache_dir = if let Result::Ok(path_str) = env::var("TIMEWALL_CACHE_DIR") {
-            PathBuf::from(path_str)
-        } else {
-            match ProjectDirs::from(APP_QUALIFIER, "", APP_NAME) {
-                Some(app_dirs) => app_dirs.cache_dir().to_path_buf(),
-                None => panic!("couldn't determine user's home directory"),
-            }
-        };
-        Self::load(cache_dir.join("last_wall"))
+        Self::load(get_cache_dir().join("last_wall"))
     }
 
     /// Load instance from given link path.
@@ -141,6 +125,17 @@ impl LastWallpaper {
     pub fn clear(&self) {
         if fs::read_link(&self.link_path).is_ok() {
             fs::remove_file(&self.link_path).ok();
+        }
+    }
+}
+
+fn get_cache_dir() -> PathBuf {
+    if let Result::Ok(path_str) = env::var("TIMEWALL_CACHE_DIR") {
+        PathBuf::from(path_str)
+    } else {
+        match ProjectDirs::from(APP_QUALIFIER, "", APP_NAME) {
+            Some(app_dirs) => app_dirs.cache_dir().to_path_buf(),
+            None => panic!("couldn't determine user's home directory"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ const DEFAULT_CONFIG_FILE_CONTENT: &str = "\
 # Dynamic location service
 # [geoclue]
 # enable = true
+# cache_fallback = true
 # prefer = false
 # timeout = 1000
 
@@ -74,6 +75,8 @@ impl Default for Daemon {
 pub struct Geoclue {
     #[serde(default = "Geoclue::enable_default_value")]
     pub enable: bool,
+    #[serde(default = "Geoclue::cache_fallback_default_value")]
+    pub cache_fallback: bool,
     #[serde(default = "Geoclue::prefer_default_value")]
     pub prefer: bool,
     #[serde(default = "Geoclue::timeout_default_value")]
@@ -82,6 +85,10 @@ pub struct Geoclue {
 
 impl Geoclue {
     const fn enable_default_value() -> bool {
+        true
+    }
+
+    const fn cache_fallback_default_value() -> bool {
         true
     }
 
@@ -99,6 +106,7 @@ impl Default for Geoclue {
         Self {
             enable: Self::enable_default_value(),
             prefer: Self::prefer_default_value(),
+            cache_fallback: Self::cache_fallback_default_value(),
             timeout: Self::timeout_default_value(),
         }
     }


### PR DESCRIPTION
When GeoClue is enabled but unavailable, use the last known location reported by GeoClue. Enabled by default, can be disabled by setting `geoclue.cache_fallback` to `false`.